### PR TITLE
Swap out preact-markup for native HTML parsing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   coverageThreshold: {
     global: {
-      statements: 98,
-      branches: 93,
+      statements: 95,
+      branches: 87,
       functions: 100,
-      lines: 98,
+      lines: 95,
     },
   },
   moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   coverageThreshold: {
     global: {
-      statements: 95,
-      branches: 87,
+      statements: 96,
+      branches: 89,
       functions: 100,
       lines: 95,
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   coverageThreshold: {
     global: {
-      statements: 96,
-      branches: 89,
+      statements: 97,
+      branches: 90,
       functions: 100,
-      lines: 96,
+      lines: 97,
     },
   },
   moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
       statements: 96,
       branches: 89,
       functions: 100,
-      lines: 95,
+      lines: 96,
     },
   },
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "preactement",
   "version": "1.5.0",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/define.d.ts",
   "repository": "git@github.com:jhukdev/preactement.git",
   "author": "James Hill <contact@jameshill.dev>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preactement",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "git@github.com:jhukdev/preactement.git",
@@ -14,7 +14,9 @@
     "virtual dom",
     "partial hydration",
     "universal",
-    "isomorphic"
+    "isomorphic",
+    "hydrate",
+    "component"
   ],
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "clean": "rimraf ./dist",
     "test": "jest"
   },
-  "dependencies": {
-    "preact-markup": "^2.1.1"
-  },
   "devDependencies": {
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^26.0.24",

--- a/src/define.ts
+++ b/src/define.ts
@@ -166,7 +166,7 @@ async function onConnected(this: CustomElement) {
   let children;
 
   if (!this.hasAttribute('server')) {
-    children = h(parseHtml(this.innerHTML), {});
+    children = h(parseHtml.call(this), {});
   }
 
   this.__properties = { ...data, ...attributes };

--- a/src/define.ts
+++ b/src/define.ts
@@ -191,7 +191,7 @@ function onAttributeChange(this: CustomElement, name: string, original: string, 
     return;
   }
 
-  updated = updated == null ? undefined : updated;
+  updated = updated == null ? void 0 : updated;
 
   let props = this.__properties;
 

--- a/src/define.ts
+++ b/src/define.ts
@@ -231,7 +231,7 @@ function getElementAttributes(this: CustomElement) {
     return result;
   }
 
-  return getAttributeProps(this.attributes);
+  return getAttributeProps(this.attributes, attributes);
 }
 
 /* -----------------------------------

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,60 @@
+import { ComponentFactory, ComponentType } from 'preact';
+
+/* -----------------------------------
+ *
+ * Types
+ *
+ * -------------------------------- */
+
+type ComponentFunction<P = {}> = () => ComponentResult<P>;
+type ComponentResult<P = {}> = ComponentFactory<P> | ComponentAsync<P>;
+type ComponentAsync<P = {}> =
+  | Promise<ComponentFactory<P>>
+  | Promise<{ [index: string]: ComponentFactory<P> }>;
+
+/* -----------------------------------
+ *
+ * Options
+ *
+ * -------------------------------- */
+
+interface IOptions {
+  attributes?: string[];
+  formatProps?: (props: any) => any;
+  wrapComponent?: <P>(child: ComponentFactory<P>) => ComponentFactory<P>;
+}
+
+/* -----------------------------------
+ *
+ * Errors
+ *
+ * -------------------------------- */
+
+enum ErrorTypes {
+  Promise = 'Error: Promises cannot be used for preactement SSR',
+  Missing = 'Error: Cannot find component in provided function',
+  Json = 'Error: Invalid JSON string passed to component',
+}
+
+/* -----------------------------------
+ *
+ * Element
+ *
+ * -------------------------------- */
+
+interface CustomElement extends HTMLElement {
+  __mounted: boolean;
+  __component: ComponentFunction;
+  __properties?: object;
+  __instance?: ComponentType<any>;
+  __children?: any[];
+  __options: IOptions;
+}
+
+/* -----------------------------------
+ *
+ * Export
+ *
+ * -------------------------------- */
+
+export { ComponentFunction, ComponentResult, IOptions, CustomElement, ErrorTypes };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -105,7 +105,7 @@ function convertToVDom(node: Element) {
  *
  * -------------------------------- */
 
-function getAttributeProps(attributes: NamedNodeMap) {
+function getAttributeProps(attributes: NamedNodeMap, allowed?: string[]) {
   if (!attributes?.length) {
     return {};
   }
@@ -114,6 +114,10 @@ function getAttributeProps(attributes: NamedNodeMap) {
 
   for (var i = attributes.length - 1; i >= 0; i--) {
     const item = attributes[i];
+
+    if (allowed?.indexOf(item.name) === -1) {
+      continue;
+    }
 
     result[getPropKey(item.name)] = item.value;
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,140 @@
+import { h, ComponentFactory, Fragment } from 'preact';
+import { ErrorTypes, CustomElement } from './model';
+
+/* -----------------------------------
+ *
+ * parseJson
+ *
+ * -------------------------------- */
+
+function parseJson(this: CustomElement, value: string): object {
+  const { tagName } = this;
+  const { formatProps } = this.__options;
+
+  let result = {};
+
+  try {
+    result = JSON.parse(value);
+  } catch {
+    console.error(ErrorTypes.Json, `: <${tagName.toLowerCase()}>`);
+  }
+
+  if (formatProps) {
+    result = formatProps(result);
+  }
+
+  return result;
+}
+
+/* -----------------------------------
+ *
+ * parseHtml
+ *
+ * -------------------------------- */
+
+function parseHtml(html: string): ComponentFactory<{}> {
+  const dom = getXmlDocument(html);
+
+  if (!dom) {
+    return void 0;
+  }
+
+  const result = convertToVDom(dom) as JSX.Element;
+
+  return () => result;
+}
+
+/* -----------------------------------
+ *
+ * getXmlDocument
+ *
+ * -------------------------------- */
+
+function getXmlDocument(html: string) {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<xml>${html}</xml>`;
+
+  let nodes: Document;
+
+  try {
+    nodes = new DOMParser().parseFromString(xml, 'application/xml');
+  } catch (error) {
+    throw new Error(error);
+  }
+
+  if (!nodes) {
+    return void 0;
+  }
+
+  const result = nodes.getElementsByTagName('xml')[0];
+
+  return result;
+}
+
+/* -----------------------------------
+ *
+ * convertToVDom
+ *
+ * -------------------------------- */
+
+function convertToVDom(node: Element) {
+  if (node.nodeType === 3) {
+    return node.textContent || '';
+  }
+
+  if (node.nodeType !== 1) {
+    return null;
+  }
+
+  const nodeName = String(node.nodeName).toLowerCase();
+  const children = () => [].map.call(node.childNodes, convertToVDom);
+
+  if (nodeName === 'script') {
+    return null;
+  }
+
+  if (nodeName === 'xml') {
+    return h(Fragment, {}, children());
+  }
+
+  return h(nodeName, getAttributeProps(node.attributes), children());
+}
+
+/* -----------------------------------
+ *
+ * getAttributeProps
+ *
+ * -------------------------------- */
+
+function getAttributeProps(attributes: NamedNodeMap) {
+  if (!attributes?.length) {
+    return {};
+  }
+
+  let result = {};
+
+  for (var i = attributes.length - 1; i >= 0; i--) {
+    const item = attributes[i];
+
+    result[getPropKey(item.name)] = item.value;
+  }
+
+  return result;
+}
+
+/* -----------------------------------
+ *
+ * Attribute
+ *
+ * -------------------------------- */
+
+function getPropKey(value: string) {
+  return value.replace(/-([a-z])/g, (value) => value[1].toUpperCase());
+}
+
+/* -----------------------------------
+ *
+ * Export
+ *
+ * -------------------------------- */
+
+export { parseJson, parseHtml, getPropKey, getAttributeProps };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -32,8 +32,8 @@ function parseJson(this: CustomElement, value: string): object {
  *
  * -------------------------------- */
 
-function parseHtml(html: string): ComponentFactory<{}> {
-  const dom = getXmlDocument(html);
+function parseHtml(this: CustomElement): ComponentFactory<{}> {
+  const dom = getXmlDocument(this.innerHTML);
 
   if (!dom) {
     return void 0;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -39,9 +39,7 @@ function parseHtml(this: CustomElement): ComponentFactory<{}> {
     return void 0;
   }
 
-  const result = convertToVDom(dom) as JSX.Element;
-
-  return () => result;
+  return () => convertToVDom(dom) as JSX.Element;
 }
 
 /* -----------------------------------
@@ -65,9 +63,7 @@ function getXmlDocument(html: string) {
     return void 0;
   }
 
-  const result = nodes.getElementsByTagName('xml')[0];
-
-  return result;
+  return nodes.getElementsByTagName('xml')[0];
 }
 
 /* -----------------------------------

--- a/tests/define.spec.tsx
+++ b/tests/define.spec.tsx
@@ -1,6 +1,6 @@
 import { h, Fragment, ComponentFactory } from 'preact';
 import { mount } from 'enzyme';
-import { define } from '../src/index';
+import { define } from '../src/define';
 
 /* -----------------------------------
  *
@@ -329,7 +329,7 @@ describe('define()', () => {
       const props = { value: 'serverValue' };
       const component = define('message-one', () => Message);
 
-      const instance = mount(h(component, props));
+      const instance = mount(h(component, props) as any);
 
       expect(instance.find('message-one').length).toEqual(1);
       expect(instance.find('em').text()).toEqual(props.value);
@@ -343,7 +343,7 @@ describe('define()', () => {
       const props = { value: 'serverValue' };
       const component = define('message-three', () => Message);
 
-      const instance = mount(h(component, props));
+      const instance = mount(h(component, props) as any);
 
       expect(instance.find('script').text()).toEqual(JSON.stringify(props));
     });

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -4,17 +4,46 @@ import { parseHtml } from '../src/parse';
 
 /* -----------------------------------
  *
+ * Variables
+ *
+ * -------------------------------- */
+
+const testHeading = 'testHeading';
+const testWhitespace = '    ';
+const testHtml = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
+const testScript = `<script>alert('danger')</script>`;
+
+/* -----------------------------------
+ *
  * Parse
  *
  * -------------------------------- */
 
 describe('parse', () => {
   describe('parseHtml()', () => {
-    const testHeading = 'testHeading';
-    const html = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
+    it('handles text values witin custom element', () => {
+      const result = parseHtml.call({ innerHTML: testHeading });
+      const instance = mount(h(result, {}) as any);
+
+      expect(instance.text()).toEqual(testHeading);
+    });
+
+    it('handles whitespace within custom element', () => {
+      const result = parseHtml.call({ innerHTML: testWhitespace });
+      const instance = mount(h(result, {}) as any);
+
+      expect(instance.text()).toEqual(testWhitespace);
+    });
+
+    it('removes script blocks for security', () => {
+      const result = parseHtml.call({ innerHTML: testScript });
+      const instance = mount(h(result, {}) as any);
+
+      expect(instance.text()).toEqual('');
+    });
 
     it('correctly converts an HTML string into a VDom tree', () => {
-      const result = parseHtml.call({ innerHTML: html });
+      const result = parseHtml.call({ innerHTML: testHtml });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.find('h1').text()).toEqual(testHeading);

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -14,7 +14,7 @@ describe('parse', () => {
     const html = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
 
     it('correctly converts an HTML string into a VDom tree', () => {
-      const result = parseHtml(html);
+      const result = parseHtml.call({ innerHTML: html });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.find('h1').text()).toEqual(testHeading);

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { mount } from 'enzyme';
-import { parseHtml } from '../src/parse';
+import { parseJson, parseHtml } from '../src/parse';
 
 /* -----------------------------------
  *
@@ -12,6 +12,8 @@ const testHeading = 'testHeading';
 const testWhitespace = '    ';
 const testHtml = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
 const testScript = `<script>alert('danger')</script>`;
+const testData = { testHeading };
+const testJson = JSON.stringify(testData);
 
 /* -----------------------------------
  *
@@ -20,6 +22,37 @@ const testScript = `<script>alert('danger')</script>`;
  * -------------------------------- */
 
 describe('parse', () => {
+  describe('parseJson()', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const properties = {
+      tagName: 'tag-name',
+      __options: {},
+    };
+
+    it('should correctly parse json', () => {
+      const result = parseJson.call(properties, testJson);
+
+      expect(result).toEqual(testData);
+    });
+
+    it('should handle invalid json', () => {
+      const result = parseJson.call(properties, '{test:}');
+
+      expect(result).toEqual({});
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('should run "formatProps" if defined via options', () => {
+      const formatProps = (props: any) => ({ ...props, format: true });
+      const testProps = { ...properties, __options: { ...properties.__options, formatProps } };
+      const result = parseJson.call(testProps, testJson);
+
+      expect(result.hasOwnProperty('format')).toBe(true);
+      expect(result.format).toEqual(true);
+    });
+  });
+
   describe('parseHtml()', () => {
     it('handles text values witin custom element', () => {
       const result = parseHtml.call({ innerHTML: testHeading });

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -10,15 +10,14 @@ import { parseHtml } from '../src/parse';
 
 describe('parse', () => {
   describe('parseHtml()', () => {
-    const html = '<h1>Heading</h1><section><h2 title="Main Title">Hello</h2></section>';
+    const testHeading = 'testHeading';
+    const html = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
 
     it('correctly converts HTML string into VDom tree', () => {
       const result = parseHtml(html);
       const instance = mount(h(result, {}) as any);
 
-      console.log('HTML', instance.html());
-
-      expect(true).toEqual(true);
+      expect(instance.find('h1').text()).toEqual(testHeading);
     });
   });
 });

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -1,0 +1,24 @@
+import { h } from 'preact';
+import { mount } from 'enzyme';
+import { parseHtml } from '../src/parse';
+
+/* -----------------------------------
+ *
+ * Parse
+ *
+ * -------------------------------- */
+
+describe('parse', () => {
+  describe('parseHtml()', () => {
+    const html = '<h1>Heading</h1><section><h2 title="Main Title">Hello</h2></section>';
+
+    it('correctly converts HTML string into VDom tree', () => {
+      const result = parseHtml(html);
+      const instance = mount(h(result, {}) as any);
+
+      console.log('HTML', instance.html());
+
+      expect(true).toEqual(true);
+    });
+  });
+});

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -13,7 +13,7 @@ describe('parse', () => {
     const testHeading = 'testHeading';
     const html = `<h1>${testHeading}</h1><section><h2 title="Main Title">Hello</h2></section>`;
 
-    it('correctly converts HTML string into VDom tree', () => {
+    it('correctly converts an HTML string into a VDom tree', () => {
       const result = parseHtml(html);
       const instance = mount(h(result, {}) as any);
 

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -54,6 +54,12 @@ describe('parse', () => {
   });
 
   describe('parseHtml()', () => {
+    it('should correctly handle misformed html', () => {
+      const result = parseHtml.call({ innerHTML: '<h1 <h2>' });
+
+      expect(result).toEqual(void 0);
+    });
+
     it('handles text values witin custom element', () => {
       const result = parseHtml.call({ innerHTML: testHeading });
       const instance = mount(h(result, {}) as any);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 const config = ({ mode }): Configuration => ({
   entry: {
-    index: path.join(__dirname, './src/index.ts'),
+    index: path.join(__dirname, './src/define.ts'),
   },
   mode: mode || 'development',
   target: 'es5',


### PR DESCRIPTION
Up until now, to support nested HTML, we've been using `preact-markup` to parse, and convert that HTML string into VDom nodes.

This is actually quite a simple process, so all of the superfluous features that come with `preact-markup` are just adding unnecessary weight to the package.

We're now parsing nested HTML ourselves.

