### PR TITLE
Added slot support for child html

### DIFF
--- a/src/define.ts
+++ b/src/define.ts
@@ -168,9 +168,7 @@ async function onConnected(this: CustomElement) {
   let children;
 
   if (!this.hasAttribute('server')) {
-    const { result } = parseHtml.call(this);
-
-    children = h(result, {});
+    children = h(parseHtml.call(this), {});
   }
 
   const properties = { ...this.__slots, ...data, ...attributes };

--- a/src/define.ts
+++ b/src/define.ts
@@ -87,6 +87,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
       element.__mounted = false;
       element.__component = component;
       element.__properties = {};
+      element.__slots = {};
       element.__children = [];
       element.__options = options;
 
@@ -108,6 +109,7 @@ function setupElement<T>(component: ComponentFunction<T>, options: IOptions = {}
     __mounted = false;
     __component = component;
     __properties = {};
+    __slots = {};
     __children = [];
     __options = options;
 
@@ -166,10 +168,14 @@ async function onConnected(this: CustomElement) {
   let children;
 
   if (!this.hasAttribute('server')) {
-    children = h(parseHtml.call(this), {});
+    const { result } = parseHtml.call(this);
+
+    children = h(result, {});
   }
 
-  this.__properties = { ...data, ...attributes };
+  const properties = { ...this.__slots, ...data, ...attributes };
+
+  this.__properties = properties;
   this.__instance = component;
   this.__children = children || [];
   this.__mounted = true;
@@ -177,7 +183,7 @@ async function onConnected(this: CustomElement) {
   this.removeAttribute('server');
   this.innerHTML = '';
 
-  render(h(component, { ...data, ...attributes, parent: this, children }), this);
+  render(h(component, { ...properties, parent: this, children }), this);
 }
 
 /* -----------------------------------

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,9 +46,20 @@ interface CustomElement extends HTMLElement {
   __mounted: boolean;
   __component: ComponentFunction;
   __properties?: object;
+  __slots?: { [index: string]: JSX.Element };
   __instance?: ComponentType<any>;
   __children?: any[];
   __options: IOptions;
+}
+
+/* -----------------------------------
+ *
+ * IProps
+ *
+ * -------------------------------- */
+
+interface IProps {
+  [index: string]: any;
 }
 
 /* -----------------------------------
@@ -57,4 +68,4 @@ interface CustomElement extends HTMLElement {
  *
  * -------------------------------- */
 
-export { ComponentFunction, ComponentResult, IOptions, CustomElement, ErrorTypes };
+export { ComponentFunction, ComponentResult, IOptions, CustomElement, ErrorTypes, IProps };

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,7 +46,7 @@ interface CustomElement extends HTMLElement {
   __mounted: boolean;
   __component: ComponentFunction;
   __properties?: object;
-  __slots?: { [index: string]: JSX.Element };
+  __slots?: { [index: string]: JSX.Element | string };
   __instance?: ComponentType<any>;
   __children?: any[];
   __options: IOptions;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -109,7 +109,7 @@ function convertToVDom(this: CustomElement, node: Element) {
   }
 
   if (slot) {
-    this.__slots[slot] = h(Fragment, {}, children());
+    this.__slots[slot] = getSlotChild(children);
 
     return null;
   }
@@ -151,6 +151,23 @@ function getAttributeProps(attributes: NamedNodeMap, allowed?: string[]): IProps
 
 function getPropKey(value: string) {
   return value.replace(/-([a-z])/g, (value) => value[1].toUpperCase());
+}
+
+/* -----------------------------------
+ *
+ * getSlotChild
+ *
+ * -------------------------------- */
+
+function getSlotChild(children: () => JSX.Element[]) {
+  const result = children();
+  const isString = (item) => typeof item === 'string';
+
+  if (result.every(isString)) {
+    return result.join(' ');
+  }
+
+  return h(Fragment, {}, result);
 }
 
 /* -----------------------------------

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,18 +3,6 @@ import { ErrorTypes, CustomElement, IProps } from './model';
 
 /* -----------------------------------
  *
- * IParsed
- *
- * -------------------------------- */
-
-interface IParsed {
-  [index: string]: any;
-  slots?: { [index: string]: JSX.Element };
-  result?: () => JSX.Element;
-}
-
-/* -----------------------------------
- *
  * parseJson
  *
  * -------------------------------- */
@@ -44,7 +32,7 @@ function parseJson(this: CustomElement, value: string) {
  *
  * -------------------------------- */
 
-function parseHtml(this: CustomElement): IParsed {
+function parseHtml(this: CustomElement): ComponentFactory<{}> {
   const dom = getXmlDocument(this.innerHTML);
 
   if (!dom) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -48,15 +48,12 @@ function parseHtml(this: CustomElement): IParsed {
   const dom = getXmlDocument(this.innerHTML);
 
   if (!dom) {
-    return {};
+    return void 0;
   }
 
   const result = convertToVDom.call(this, dom);
 
-  return {
-    slots: this.__slots,
-    result: () => result as JSX.Element,
-  };
+  return () => result;
 }
 
 /* -----------------------------------

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -85,6 +85,7 @@ function convertToVDom(this: CustomElement, node: Element) {
 
   const nodeName = String(node.nodeName).toLowerCase();
   const childNodes = Array.from(node.childNodes);
+
   const children = () => childNodes.map((child) => convertToVDom.call(this, child));
   const { slot, ...props } = getAttributeProps(node.attributes);
 
@@ -97,7 +98,7 @@ function convertToVDom(this: CustomElement, node: Element) {
   }
 
   if (slot) {
-    this.__slots[slot] = getSlotChild(children);
+    this.__slots[slot] = getSlotChildren(children());
 
     return null;
   }
@@ -143,19 +144,18 @@ function getPropKey(value: string) {
 
 /* -----------------------------------
  *
- * getSlotChild
+ * getSlotChildren
  *
  * -------------------------------- */
 
-function getSlotChild(children: () => JSX.Element[]) {
-  const result = children();
+function getSlotChildren(children: JSX.Element[]) {
   const isString = (item) => typeof item === 'string';
 
-  if (result.every(isString)) {
-    return result.join(' ');
+  if (children.every(isString)) {
+    return children.join(' ');
   }
 
-  return h(Fragment, {}, result);
+  return h(Fragment, {}, children);
 }
 
 /* -----------------------------------

--- a/tests/define.spec.tsx
+++ b/tests/define.spec.tsx
@@ -268,6 +268,21 @@ describe('define()', () => {
 
       expect(root.innerHTML).toContain(`<em>${props.Value}</em>`);
     });
+
+    it('correctly segments <* slot="{key}" /> elements into props', () => {
+      const customTitle = '<em>customTitle</em>';
+      const html = `<div slot="customTitle">${customTitle}</div>`;
+
+      define('message-twelve', () => Message);
+
+      const element = document.createElement('message-twelve');
+
+      element.innerHTML = html;
+
+      root.appendChild(element);
+
+      expect(root.innerHTML).toContain(`<h2>${customTitle}</h2><em></em>`);
+    });
   });
 
   describe('when run in the browser (no "Reflect.construct")', () => {

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -55,34 +55,34 @@ describe('parse', () => {
 
   describe('parseHtml()', () => {
     it('should correctly handle misformed html', () => {
-      const { result } = parseHtml.call({ innerHTML: '<h1 <h2>' });
+      const result = parseHtml.call({ innerHTML: '<h1 <h2>' });
 
       expect(result).toEqual(void 0);
     });
 
     it('handles text values witin custom element', () => {
-      const { result } = parseHtml.call({ innerHTML: testHeading });
+      const result = parseHtml.call({ innerHTML: testHeading });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testHeading);
     });
 
     it('handles whitespace within custom element', () => {
-      const { result } = parseHtml.call({ innerHTML: testWhitespace });
+      const result = parseHtml.call({ innerHTML: testWhitespace });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testWhitespace);
     });
 
     it('removes script blocks for security', () => {
-      const { result } = parseHtml.call({ innerHTML: testScript });
+      const result = parseHtml.call({ innerHTML: testScript });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual('');
     });
 
     it('correctly converts an HTML string into a VDom tree', () => {
-      const { result } = parseHtml.call({ innerHTML: testHtml });
+      const result = parseHtml.call({ innerHTML: testHtml });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.find('h1').text()).toEqual(testHeading);

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -87,5 +87,21 @@ describe('parse', () => {
 
       expect(instance.find('h1').text()).toEqual(testHeading);
     });
+
+    it('should remove <* slot="{key}"> and apply to props', () => {
+      const slots = {};
+      const slotKey = 'slotKey';
+      const slotValue = 'slotValue';
+
+      const slotHtml = `<em slot="${slotKey}">${slotValue}</em>`;
+      const headingHtml = `<h1>${testHeading}</h1>`;
+      const testHtml = `<section>${headingHtml}${slotHtml}</section>`;
+
+      const result = parseHtml.call({ innerHTML: testHtml, __slots: slots });
+      const instance = mount(h(result, {}) as any);
+
+      expect(instance.html()).toEqual(`<section>${headingHtml}</section>`);
+      expect(slots).toEqual({ [slotKey]: slotValue });
+    });
   });
 });

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -55,34 +55,34 @@ describe('parse', () => {
 
   describe('parseHtml()', () => {
     it('should correctly handle misformed html', () => {
-      const result = parseHtml.call({ innerHTML: '<h1 <h2>' });
+      const { result } = parseHtml.call({ innerHTML: '<h1 <h2>' });
 
       expect(result).toEqual(void 0);
     });
 
     it('handles text values witin custom element', () => {
-      const result = parseHtml.call({ innerHTML: testHeading });
+      const { result } = parseHtml.call({ innerHTML: testHeading });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testHeading);
     });
 
     it('handles whitespace within custom element', () => {
-      const result = parseHtml.call({ innerHTML: testWhitespace });
+      const { result } = parseHtml.call({ innerHTML: testWhitespace });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual(testWhitespace);
     });
 
     it('removes script blocks for security', () => {
-      const result = parseHtml.call({ innerHTML: testScript });
+      const { result } = parseHtml.call({ innerHTML: testScript });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.text()).toEqual('');
     });
 
     it('correctly converts an HTML string into a VDom tree', () => {
-      const result = parseHtml.call({ innerHTML: testHtml });
+      const { result } = parseHtml.call({ innerHTML: testHtml });
       const instance = mount(h(result, {}) as any);
 
       expect(instance.find('h1').text()).toEqual(testHeading);


### PR DESCRIPTION
- Added additional step that parses child HTML with `slot="{propKey}"` attributes
- Converts html content into VDom tree
- Assigns VDom tree to component props using the `slot` attribute value
- Removes `<* slot="*" />` elements from children props 