### PR TITLE
Fixed parsing error for non self closing tags in child HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ function HeroBanner({ children }) {
 }
 ```
 
+### Important
+
+Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser it can be quite lax, and this might result in unusual bugs if the contents passed are not properly sanitised. For example:
+
+This will result in a Preact error:
+
+```jsx
+<p Hello
+```
+
+This will result in an H1 tag:
+
+```jsx
+<h1>Hello
+<h1>Hello</h3>
+```
+
 ### Slots
 
 `preactement` now supports the use of `<* slot="{key}" />` elements, to assign string values or full blocks of HTML to your component props. This is useful if your server defines layout rules that are outside of the scope of your component. For example, given the custom element below:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ function HeroBanner({ children }) {
 
 ### Important
 
-Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser which can be quite lax, if the contents passed are not properly sanitised or structured this might result in unusual bugs. For example:
+Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser which is quite lax, any html passed that is not properly sanitised or structured might result in unusual bugs. For example:
 
 This will result in a Preact error:
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ function HeroBanner({ children }) {
 
 ### Important
 
-Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser which can be quite lax, this might result in unusual bugs if the contents passed are not properly sanitised or structured. For example:
+Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser which can be quite lax, if the contents passed are not properly sanitised or structured this might result in unusual bugs. For example:
 
 This will result in a Preact error:
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ function HeroBanner({ children }) {
 
 ### Important
 
-Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser it can be quite lax, and this might result in unusual bugs if the contents passed are not properly sanitised. For example:
+Any HTML provided to the custom element **must be valid**; As we're using the DOM's native parser which can be quite lax, this might result in unusual bugs if the contents passed are not properly sanitised or structured. For example:
 
 This will result in a Preact error:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 97,
-      branches: 89,
+      branches: 88,
       functions: 100,
       lines: 97,
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preactement",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "repository": "git@github.com:jhukdev/preactement.git",
   "author": "James Hill <contact@jameshill.dev>",
   "license": "MIT",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -33,7 +33,7 @@ function parseJson(this: CustomElement, value: string) {
  * -------------------------------- */
 
 function parseHtml(this: CustomElement): ComponentFactory<{}> {
-  const dom = getXmlDocument(this.innerHTML);
+  const dom = getDocument(this.innerHTML);
 
   if (!dom) {
     return void 0;
@@ -46,26 +46,26 @@ function parseHtml(this: CustomElement): ComponentFactory<{}> {
 
 /* -----------------------------------
  *
- * getXmlDocument
+ * getDocument
  *
  * -------------------------------- */
 
-function getXmlDocument(html: string) {
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<xml>${html}</xml>`;
+function getDocument(html: string) {
+  const value = `<!DOCTYPE html>\n<html><body>${html}</body></html>`;
 
   let nodes: Document;
 
   try {
-    nodes = new DOMParser().parseFromString(xml, 'application/xml');
-  } catch (error) {
-    throw new Error(error);
+    nodes = new DOMParser().parseFromString(value, 'text/html');
+  } catch {
+    // no-op
   }
 
   if (!nodes) {
     return void 0;
   }
 
-  return nodes.getElementsByTagName('xml')[0];
+  return nodes.body;
 }
 
 /* -----------------------------------
@@ -93,7 +93,7 @@ function convertToVDom(this: CustomElement, node: Element) {
     return null;
   }
 
-  if (nodeName === 'xml') {
+  if (nodeName === 'body') {
     return h(Fragment, {}, children());
   }
 

--- a/tests/define.spec.tsx
+++ b/tests/define.spec.tsx
@@ -107,7 +107,7 @@ describe('define()', () => {
     it('sets contained HTML as children prop when not server rendered', async () => {
       const props = { value: 'childMarkup' };
       const json = `<script type="application/json">${JSON.stringify(props)}</script>`;
-      const html = '<p data-title="test">Testing</p><button title="test">Click here</button>';
+      const html = '<p data-title="test">Testing</p><br><button title="test">Click here</button>';
 
       define('message-three', () => Message);
 

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -30,6 +30,8 @@ describe('parse', () => {
       __options: {},
     };
 
+    afterAll(() => errorSpy.mockClear());
+
     it('should correctly parse json', () => {
       const result = parseJson.call(properties, testJson);
 
@@ -56,10 +58,8 @@ describe('parse', () => {
   describe('parseHtml()', () => {
     it('should correctly handle misformed html', () => {
       const testText = 'testText';
-      const result = parseHtml.call({ innerHTML: `<h1>Hello` });
+      const result = parseHtml.call({ innerHTML: `<h1>${testText}` });
       const instance = mount(h(result, {}) as any);
-
-      console.log('Misformed HTML:', instance.html());
 
       expect(instance.html()).toEqual(`<h1>${testText}</h1>`);
     });

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -54,12 +54,6 @@ describe('parse', () => {
   });
 
   describe('parseHtml()', () => {
-    it('should correctly handle misformed html', () => {
-      const result = parseHtml.call({ innerHTML: '<h1 <h2>' });
-
-      expect(result).toEqual(void 0);
-    });
-
     it('handles text values witin custom element', () => {
       const result = parseHtml.call({ innerHTML: testHeading });
       const instance = mount(h(result, {}) as any);

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -54,6 +54,16 @@ describe('parse', () => {
   });
 
   describe('parseHtml()', () => {
+    it('should correctly handle misformed html', () => {
+      const testText = 'testText';
+      const result = parseHtml.call({ innerHTML: `<h1>Hello` });
+      const instance = mount(h(result, {}) as any);
+
+      console.log('Misformed HTML:', instance.html());
+
+      expect(instance.html()).toEqual(`<h1>${testText}</h1>`);
+    });
+
     it('handles text values witin custom element', () => {
       const result = parseHtml.call({ innerHTML: testHeading });
       const instance = mount(h(result, {}) as any);


### PR DESCRIPTION
Using elements like `<b>` currently cause a parsing error when provided as child HTML for a components element. We're currently using the DOM's XML parser (for speed), but this might prove to restrictive.

- Changed child HTML parser type to `text/html`
- Updated unit tests to reflect new parser

**Note**
The only down side to this is the lax nature of the DOM's HTML parser. Previously, any misformed HTML would result in an error. Now with this change, you'll likely either end up with resolved markup (e.g `<h1></h2>` = `<h1></h1>`) or a Preact error if the parser just returns the element as a text node.

Validating HTML input is outside of the scope of this package, and would significantly increase complexity and file size, which isn't ideal. I've made a [note in the `README`](https://github.com/jhukdev/preactement/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R146) to highlight the potential pitfalls.